### PR TITLE
corrected discovery option

### DIFF
--- a/lib/milight.setup.js
+++ b/lib/milight.setup.js
@@ -3,7 +3,7 @@ var Promise = require('bluebird');
 var init = require('./milight.init.js');
 
 module.exports = function() {
-    return milight.discoverBridges({type : 'All'})
+    return milight.discoverBridges({type : 'all'})
         .then((bridges) => {
 
             // foreach bridge, we create a device bridge


### PR DESCRIPTION
For the time being, the `type` option value for discovery is case sensitive and must be provided in lower case letters. 

Besides that, I think you need to add some type discrimator to the device setup to be able to decide which type of bridge (v6 or legacy) it is later of (as part of device execution). I am not sure whether or not this can be simply added to the device object as I am not so familiar with gladys, yet. It may look like as follows:

```
device: {
   ...
   type: bridge.type  // one of 'v6' or 'legacy'
}